### PR TITLE
Fixes for the base randomizer :

### DIFF
--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -4973,7 +4973,16 @@ void WP_SaberStartMissileBlockCheck( gentity_t *self, usercmd_t *ucmd  )
 		&& self->targetname && !Q_strncmp(self->targetname, "reelo_thug", 10)
 		|| cg_enableRandomizer.integer && !Q_stricmp(level.mapname, "ns_starpad")
 		&& self->targetname && !Q_strncmp(self->targetname, "bea", 3)) {
+		// Excessive, but disable saber defense at each check
+		self->client->ps.forcePowersKnown &= ~(1 << FP_SABER_DEFENSE); // Remove the bit
+		self->client->ps.forcePowerLevel[FP_SABER_DEFENSE] = FORCE_LEVEL_0;
 		return;
+	}
+	if (cg_enableRandomizer.integer && !Q_stricmp(level.mapname, "artus_topside") && self->targetname && !Q_strncmp(self->targetname, "cinematic9_desann", 17))
+	{
+		// Excessive, but give this NPC saber defense 3 at each check
+		self->client->ps.forcePowersKnown |= (1 << FP_SABER_DEFENSE);
+		self->client->ps.forcePowerLevel[FP_SABER_DEFENSE] = FORCE_LEVEL_3;
 	}
 
 	if ( self->client->ps.weapon != WP_SABER )

--- a/code/randomizer/RandomizerUtils.cpp
+++ b/code/randomizer/RandomizerUtils.cpp
@@ -112,7 +112,7 @@ void initialiseNameMap() {
 	teamsByName["NPC_BespinCop"] = TEAM_PLAYER;
 	teamsByName["NPC_Reborn"] = TEAM_ENEMY;
 	teamsByName["NPC_ShadowTrooper"] = TEAM_ENEMY;
-	//teamsByName["NPC_MineMonster"] = TEAM_NEUTRAL;
+	//teamsByName["NPC_MineMonster"] = TEAM_NEUTRAL; // Breaks their AI
 	teamsByName["NPC_MineMonster"] = TEAM_ENEMY;
 	teamsByName["NPC_Droid_Interrogator"] = TEAM_ENEMY;
 	teamsByName["NPC_Droid_Probe"] = TEAM_ENEMY;
@@ -125,6 +125,7 @@ void initialiseNameMap() {
 	teamsByName["NPC_Droid_R5D2"] = TEAM_PLAYER;
 	teamsByName["NPC_Droid_Protocol"] = TEAM_PLAYER;
 	teamsByName["NPC_Galak_Mech"] = TEAM_ENEMY;
+	teamsByName["NPC_Droid_ATST"] = TEAM_ENEMY;
 	teamsByName["NPC_SwampTrooper"] = TEAM_ENEMY;
 }
 
@@ -167,6 +168,7 @@ void initialiseMapByClass() {
 	teamsByClass[CLASS_PROTOCOL] = TEAM_PLAYER;
 	teamsByClass[CLASS_SWAMPTROOPER] = TEAM_ENEMY;
 	teamsByClass[CLASS_GALAKMECH] = TEAM_ENEMY;
+	teamsByClass[CLASS_ATST] = TEAM_ENEMY;
 	teamsByClass[CLASS_NONE] = TEAM_PLAYER;
 }
 


### PR DESCRIPTION
- NPC replacing Desann in artus_topside can properly reflect projectiles.
- NPC replacing Reelo's thgs at the end of ns_starpad can't reflect projectiles even if they are saber wielder.
- Fixed ATSTs team from free to enemy.